### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
         default: "true"
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/ciscojuan/tourisplan/security/code-scanning/4](https://github.com/ciscojuan/tourisplan/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the jobs in this workflow only require read access to the repository contents, we will set `contents: read` as the minimal permission. This will be applied at the workflow level to cover all jobs (`lint`, `build`, and `type-check`), ensuring that no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
